### PR TITLE
Switch to Conversive Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -788,18 +788,6 @@
                 "node-fetch": "^2.6.0"
             }
         },
-        "@opendialogai/vue-beautiful-chat": {
-            "version": "git://github.com/opendialogai/vue-beautiful-chat.git#43ceb8764d7e80127461b13421cd5efe2055e92f",
-            "from": "git://github.com/opendialogai/vue-beautiful-chat.git#0.5.2",
-            "requires": {
-                "babel-preset-env": "^1.7.0",
-                "emoji-js": "^3.4.1",
-                "vue-linkify": "^1.0.1",
-                "vue-plain-slider": "^1.1.1",
-                "vue-select": "^3.4.0",
-                "vue2-animate": "^2.1.3"
-            }
-        },
         "@reststate/client": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/@reststate/client/-/client-0.0.8.tgz",
@@ -1077,6 +1065,12 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1174,6 +1168,12 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
         "ansi-colors": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -1232,6 +1232,16 @@
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
+        "are-we-there-yet": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "dev": true,
+            "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1263,6 +1273,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
         "array-flatten": {
@@ -1308,6 +1324,15 @@
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
             "dev": true
         },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
         "asn1.js": {
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1346,6 +1371,12 @@
                 }
             }
         },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1379,10 +1410,22 @@
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
+        "async-foreach": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "dev": true
+        },
         "async-limiter": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
             "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
         "atob": {
@@ -1413,6 +1456,18 @@
                     "dev": true
                 }
             }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "dev": true
         },
         "axios": {
             "version": "0.19.0",
@@ -2089,8 +2144,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -2159,6 +2213,15 @@
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
             "dev": true
         },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2170,6 +2233,15 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.0"
+            }
         },
         "bluebird": {
             "version": "3.7.1",
@@ -2265,7 +2337,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2434,6 +2505,12 @@
             "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
             "dev": true
         },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
         "builtin-status-codes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -2540,6 +2617,24 @@
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
         },
+        "camelcase-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                    "dev": true
+                }
+            }
+        },
         "caniuse-api": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -2556,6 +2651,12 @@
             "version": "1.0.30000984",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
             "integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA=="
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
             "version": "2.4.2",
@@ -2623,6 +2724,12 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
@@ -2729,6 +2836,12 @@
                 "shallow-clone": "^3.0.0"
             }
         },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
         "coa": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -2793,6 +2906,15 @@
             "requires": {
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
+            }
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -2866,8 +2988,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -2911,6 +3032,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
             "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+            "dev": true
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
         "consolidate": {
@@ -2988,26 +3115,6 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
-        },
-        "copy-webpack-plugin": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.0.5.tgz",
-            "integrity": "sha512-7N68eIoQTyudAuxkfPT7HzGoQ+TsmArN/I3HFwG+lVE3FNzqvZKIiaxtYh4o3BIznioxUvx9j26+Rtsc9htQUQ==",
-            "dev": true,
-            "requires": {
-                "cacache": "^12.0.3",
-                "find-cache-dir": "^2.1.0",
-                "glob-parent": "^3.1.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.1",
-                "loader-utils": "^1.2.3",
-                "minimatch": "^3.0.4",
-                "normalize-path": "^3.0.0",
-                "p-limit": "^2.2.1",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.0",
-                "webpack-log": "^2.0.0"
-            }
         },
         "core-js": {
             "version": "3.4.5",
@@ -3197,47 +3304,34 @@
             }
         },
         "css-loader": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
-            "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.2.tgz",
+            "integrity": "sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "css-selector-tokenizer": "^0.7.0",
-                "icss-utils": "^2.1.0",
-                "loader-utils": "^1.0.2",
-                "lodash": "^4.17.11",
-                "postcss": "^6.0.23",
-                "postcss-modules-extract-imports": "^1.2.0",
-                "postcss-modules-local-by-default": "^1.2.0",
-                "postcss-modules-scope": "^1.1.0",
-                "postcss-modules-values": "^1.3.0",
-                "postcss-value-parser": "^3.3.0",
-                "source-list-map": "^2.0.0"
+                "camelcase": "^5.3.1",
+                "cssesc": "^3.0.0",
+                "icss-utils": "^4.1.1",
+                "loader-utils": "^1.2.3",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.23",
+                "postcss-modules-extract-imports": "^2.0.0",
+                "postcss-modules-local-by-default": "^3.0.2",
+                "postcss-modules-scope": "^2.1.1",
+                "postcss-modules-values": "^3.0.0",
+                "postcss-value-parser": "^4.0.2",
+                "schema-utils": "^2.6.0"
             },
             "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                "schema-utils": {
+                    "version": "2.6.4",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+                    "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "ajv": "^6.10.2",
+                        "ajv-keywords": "^3.4.1"
                     }
-                },
-                "postcss-value-parser": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
                 }
             }
         },
@@ -3260,48 +3354,14 @@
             "dev": true
         },
         "css-selector-tokenizer": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-            "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
+            "integrity": "sha512-yj856NGuAymN6r8bn8/Jl46pR+OC3eEvAhfGYDUe7YPtTPAYrSSw4oAniZ9Y8T5B92hjhwTBLUen0/vKPxf6pw==",
             "dev": true,
             "requires": {
-                "cssesc": "^0.1.0",
-                "fastparse": "^1.1.1",
-                "regexpu-core": "^1.0.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                },
-                "regexpu-core": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-                    "dev": true,
-                    "requires": {
-                        "regenerate": "^1.2.1",
-                        "regjsgen": "^0.2.0",
-                        "regjsparser": "^0.1.4"
-                    }
-                },
-                "regjsgen": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-                    "dev": true
-                },
-                "regjsparser": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                    "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-                    "dev": true,
-                    "requires": {
-                        "jsesc": "~0.5.0"
-                    }
-                }
+                "cssesc": "^3.0.0",
+                "fastparse": "^1.1.2",
+                "regexpu-core": "^4.6.0"
             }
         },
         "css-tree": {
@@ -3340,9 +3400,9 @@
             "dev": true
         },
         "cssesc": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
         },
         "cssnano": {
@@ -3431,6 +3491,15 @@
                 "css-tree": "1.0.0-alpha.37"
             }
         },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "^1.0.1"
+            }
+        },
         "cyclist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -3447,6 +3516,15 @@
                 "type": "^1.0.1"
             }
         },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
         "de-indent": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -3459,6 +3537,12 @@
             "requires": {
                 "ms": "^2.1.1"
             }
+        },
+        "debug-log": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+            "dev": true
         },
         "decamelize": {
             "version": "1.2.0",
@@ -3557,6 +3641,20 @@
                 }
             }
         },
+        "deglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+            "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+            "dev": true,
+            "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+            }
+        },
         "del": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -3594,6 +3692,18 @@
                     }
                 }
             }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -3645,15 +3755,6 @@
                 "randombytes": "^2.0.0"
             }
         },
-        "dir-glob": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-            "dev": true,
-            "requires": {
-                "path-type": "^3.0.0"
-            }
-        },
         "dns-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -3692,7 +3793,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
             "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-            "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
                 "entities": "^2.0.0"
@@ -3701,8 +3801,7 @@
                 "domelementtype": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-                    "dev": true
+                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
                 }
             }
         },
@@ -3715,14 +3814,20 @@
         "domelementtype": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-            "dev": true
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "requires": {
+                "domelementtype": "1"
+            }
         },
         "domutils": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-            "dev": true,
             "requires": {
                 "dom-serializer": "0",
                 "domelementtype": "1"
@@ -3759,6 +3864,16 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0",
                 "stream-shift": "^1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ee-first": {
@@ -3853,8 +3968,7 @@
         "entities": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-            "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-            "dev": true
+            "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
         },
         "errno": {
             "version": "0.1.7",
@@ -4049,6 +4163,22 @@
                 "object.entries": "^1.1.0"
             }
         },
+        "eslint-config-standard": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+            "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA=="
+        },
+        "eslint-config-standard-jsx": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
+            "integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
+            "dev": true
+        },
+        "eslint-config-vue": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-vue/-/eslint-config-vue-2.0.2.tgz",
+            "integrity": "sha1-o6sQBImeSTJ6lMY+JNR6OWsvSEg="
+        },
         "eslint-import-resolver-alias": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
@@ -4174,6 +4304,43 @@
                 }
             }
         },
+        "eslint-plugin-es": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
+            "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+            "requires": {
+                "eslint-utils": "^2.0.0",
+                "regexpp": "^3.0.0"
+            },
+            "dependencies": {
+                "eslint-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+                    "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+                    "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+                },
+                "regexpp": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+                    "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+                }
+            }
+        },
+        "eslint-plugin-html": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.0.0.tgz",
+            "integrity": "sha512-PQcGippOHS+HTbQCStmH5MY1BF2MaU8qW/+Mvo/8xTa/ioeMXdSP+IiaBw2+nh0KEMfYQKuTz1Zo+vHynjwhbg==",
+            "requires": {
+                "htmlparser2": "^3.10.1"
+            }
+        },
         "eslint-plugin-import": {
             "version": "2.18.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
@@ -4219,6 +4386,77 @@
                     "dev": true
                 }
             }
+        },
+        "eslint-plugin-node": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz",
+            "integrity": "sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==",
+            "requires": {
+                "eslint-plugin-es": "^3.0.0",
+                "eslint-utils": "^2.0.0",
+                "ignore": "^5.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.10.1",
+                "semver": "^6.1.0"
+            },
+            "dependencies": {
+                "eslint-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+                    "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+                    "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+                },
+                "ignore": {
+                    "version": "5.1.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
+        "eslint-plugin-promise": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+            "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw=="
+        },
+        "eslint-plugin-react": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+            "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+            "dev": true,
+            "requires": {
+                "doctrine": "^2.0.2",
+                "has": "^1.0.1",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.0"
+            },
+            "dependencies": {
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-standard": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+            "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ=="
         },
         "eslint-plugin-vue": {
             "version": "5.2.3",
@@ -4503,6 +4741,12 @@
                 }
             }
         },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -4619,6 +4863,12 @@
                 }
             }
         },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -4691,13 +4941,25 @@
             }
         },
         "file-loader": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-            "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+            "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.0.2",
-                "schema-utils": "^1.0.0"
+                "schema-utils": "^0.4.5"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "0.4.7",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+                    "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
             }
         },
         "file-type": {
@@ -4778,6 +5040,12 @@
                 "pkg-dir": "^3.0.0"
             }
         },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
+        },
         "find-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -4857,6 +5125,23 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
         },
         "forwarded": {
             "version": "0.1.2",
@@ -5504,6 +5789,18 @@
                 }
             }
         },
+        "fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            }
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5515,10 +5812,63 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "gaze": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "dev": true,
+            "requires": {
+                "globule": "^1.0.0"
+            }
+        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
         },
         "get-stream": {
@@ -5535,6 +5885,15 @@
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
         },
         "glob": {
             "version": "7.1.4",
@@ -5617,28 +5976,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
-        "globby": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
-        },
         "globs": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/globs/-/globs-0.1.4.tgz",
@@ -5646,6 +5983,17 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.1"
+            }
+        },
+        "globule": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+            "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
+            "dev": true,
+            "requires": {
+                "glob": "~7.1.1",
+                "lodash": "~4.17.12",
+                "minimatch": "~3.0.2"
             }
         },
         "graceful-fs": {
@@ -5665,6 +6013,22 @@
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
             "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
             "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
         },
         "has": {
             "version": "1.0.3",
@@ -5692,6 +6056,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
             "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+        },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -5858,6 +6228,36 @@
                 "uglify-js": "3.4.x"
             }
         },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "http-deceiver": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -5914,6 +6314,17 @@
                 "micromatch": "^3.1.10"
             }
         },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
         "https-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -5936,31 +6347,12 @@
             "dev": true
         },
         "icss-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+            "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
             "dev": true,
             "requires": {
-                "postcss": "^6.0.1"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "postcss": "^7.0.14"
             }
         },
         "ieee754": {
@@ -6108,6 +6500,21 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "in-publish": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
         "indexes-of": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -6133,8 +6540,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
             "version": "1.3.5",
@@ -6379,6 +6785,12 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
+        "is-finite": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "dev": true
+        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -6450,6 +6862,12 @@
                 "path-is-inside": "^1.0.2"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6504,6 +6922,18 @@
                 "has-symbols": "^1.0.0"
             }
         },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6534,10 +6964,22 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
         },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
         "jquery": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
             "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+            "dev": true
+        },
+        "js-base64": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+            "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
             "dev": true
         },
         "js-cookie": {
@@ -6565,6 +7007,12 @@
                 "esprima": "^4.0.0"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6574,6 +7022,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
         "json-schema-traverse": {
@@ -6586,6 +7040,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
         "json3": {
@@ -6611,10 +7071,32 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
         "jstz": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/jstz/-/jstz-2.1.1.tgz",
             "integrity": "sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA=="
+        },
+        "jsx-ast-utils": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+            "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.0.3",
+                "object.assign": "^4.1.0"
+            }
         },
         "killable": {
             "version": "1.0.1",
@@ -6672,6 +7154,109 @@
                 "webpack-merge": "^4.1.0",
                 "webpack-notifier": "^1.5.1",
                 "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "css-loader": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
+                    "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "^6.26.0",
+                        "css-selector-tokenizer": "^0.7.0",
+                        "icss-utils": "^2.1.0",
+                        "loader-utils": "^1.0.2",
+                        "lodash": "^4.17.11",
+                        "postcss": "^6.0.23",
+                        "postcss-modules-extract-imports": "^1.2.0",
+                        "postcss-modules-local-by-default": "^1.2.0",
+                        "postcss-modules-scope": "^1.1.0",
+                        "postcss-modules-values": "^1.3.0",
+                        "postcss-value-parser": "^3.3.0",
+                        "source-list-map": "^2.0.0"
+                    }
+                },
+                "file-loader": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
+                    "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+                    "dev": true,
+                    "requires": {
+                        "loader-utils": "^1.0.2",
+                        "schema-utils": "^1.0.0"
+                    }
+                },
+                "icss-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+                    "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+                    "dev": true,
+                    "requires": {
+                        "postcss": "^6.0.1"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "postcss-modules-extract-imports": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+                    "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+                    "dev": true,
+                    "requires": {
+                        "postcss": "^6.0.1"
+                    }
+                },
+                "postcss-modules-local-by-default": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+                    "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+                    "dev": true,
+                    "requires": {
+                        "css-selector-tokenizer": "^0.7.0",
+                        "postcss": "^6.0.1"
+                    }
+                },
+                "postcss-modules-scope": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+                    "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+                    "dev": true,
+                    "requires": {
+                        "css-selector-tokenizer": "^0.7.0",
+                        "postcss": "^6.0.1"
+                    }
+                },
+                "postcss-modules-values": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+                    "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+                    "dev": true,
+                    "requires": {
+                        "icss-replace-symbols": "^1.1.0",
+                        "postcss": "^6.0.1"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "last-call-webpack-plugin": {
@@ -6848,6 +7433,16 @@
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
+            }
+        },
         "lower-case": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -6892,6 +7487,12 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
         },
         "map-visit": {
@@ -6972,6 +7573,105 @@
             "requires": {
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
+            }
+        },
+        "meow": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "^0.2.0"
+                    }
+                }
             }
         },
         "merge-descriptors": {
@@ -7067,6 +7767,32 @@
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
             "dev": true
         },
+        "mini-css-extract-plugin": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz",
+            "integrity": "sha512-a3Y4of27Wz+mqK3qrcd3VhYz6cU0iW5x3Sgvqzbj+XmlrSizmvu8QQMl5oMYJjgHOC4iyt+w7l4umP+dQeW3bw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "normalize-url": "1.9.1",
+                "schema-utils": "^1.0.0",
+                "webpack-sources": "^1.1.0"
+            },
+            "dependencies": {
+                "normalize-url": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                    "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "^4.0.1",
+                        "prepend-http": "^1.0.0",
+                        "query-string": "^4.1.0",
+                        "sort-keys": "^1.0.0"
+                    }
+                }
+            }
+        },
         "minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7083,7 +7809,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -7196,8 +7921,7 @@
             "version": "2.14.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
             "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -7268,6 +7992,34 @@
             "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
             "dev": true
         },
+        "node-gyp": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+            "dev": true,
+            "requires": {
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "^2.87.0",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
         "node-libs-browser": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -7335,6 +8087,93 @@
                 }
             }
         },
+        "node-sass": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+            "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+            "dev": true,
+            "requires": {
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash": "^4.17.15",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.13.2",
+                "node-gyp": "^3.8.0",
+                "npmlog": "^4.0.0",
+                "request": "^2.88.0",
+                "sass-graph": "^2.2.4",
+                "stdout-stream": "^1.4.0",
+                "true-case-path": "^1.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
+                }
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
         "normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7374,6 +8213,18 @@
                 "path-key": "^2.0.0"
             }
         },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
+            "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
         "nth-check": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -7393,6 +8244,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
@@ -7620,6 +8477,12 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
         "os-locale": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -7636,6 +8499,16 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
         },
         "p-defer": {
             "version": "1.0.0",
@@ -7853,6 +8726,12 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
         "pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -7874,6 +8753,100 @@
                 "pinkie": "^2.0.0"
             }
         },
+        "pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
+        },
+        "pkg-config": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+            "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+            "dev": true,
+            "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
         "pkg-dir": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -7882,6 +8855,12 @@
             "requires": {
                 "find-up": "^3.0.0"
             }
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "dev": true
         },
         "popper.js": {
             "version": "1.16.0",
@@ -8199,118 +9178,70 @@
             }
         },
         "postcss-modules-extract-imports": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-            "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+            "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
             "dev": true,
             "requires": {
-                "postcss": "^6.0.1"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "postcss": "^7.0.5"
             }
         },
         "postcss-modules-local-by-default": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+            "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "icss-utils": "^4.1.1",
+                "postcss": "^7.0.16",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.0.0"
             },
             "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                "postcss-selector-parser": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+                    "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "cssesc": "^3.0.0",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
                     }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
                 }
             }
         },
         "postcss-modules-scope": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
+            "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "postcss": "^7.0.6",
+                "postcss-selector-parser": "^6.0.0"
             },
             "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                "postcss-selector-parser": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+                    "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "cssesc": "^3.0.0",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
                     }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
                 }
             }
         },
         "postcss-modules-values": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+            "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "^1.1.0",
-                "postcss": "^6.0.1"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "icss-utils": "^4.0.0",
+                "postcss": "^7.0.6"
             }
         },
         "postcss-normalize-charset": {
@@ -8589,6 +9520,12 @@
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
         "prettier": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -8629,6 +9566,17 @@
             "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
             "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
         },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -8649,6 +9597,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
             "dev": true
         },
         "public-encrypt": {
@@ -8716,6 +9670,16 @@
             "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
             "dev": true
         },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
+        },
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8778,6 +9742,12 @@
                     "dev": true
                 }
             }
+        },
+        "react-is": {
+            "version": "16.13.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+            "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+            "dev": true
         },
         "read-pkg": {
             "version": "2.0.0",
@@ -8908,6 +9878,16 @@
                 }
             }
         },
+        "redent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
+            "requires": {
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
+            }
+        },
         "regenerate": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -9022,11 +10002,56 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
         "replace-ext": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
             "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
             "dev": true
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                }
+            }
         },
         "require-directory": {
             "version": "2.1.1",
@@ -9039,6 +10064,39 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+            },
+            "dependencies": {
+                "caller-path": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+                    "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^0.2.0"
+                    }
+                },
+                "callsites": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+                    "dev": true
+                }
+            }
         },
         "requires-port": {
             "version": "1.0.0",
@@ -9238,6 +10296,12 @@
                 "is-promise": "^2.1.0"
             }
         },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
+        },
         "run-queue": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -9245,6 +10309,21 @@
             "dev": true,
             "requires": {
                 "aproba": "^1.1.1"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "*"
             }
         },
         "rxjs": {
@@ -9285,6 +10364,224 @@
                 "chokidar": ">=2.0.0 <4.0.0"
             }
         },
+        "sass-graph": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                    "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                    "dev": true,
+                    "requires": {
+                        "lcid": "^1.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
+                    }
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "^0.2.0"
+                    }
+                },
+                "which-module": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+                    "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
+                }
+            }
+        },
         "sass-loader": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.3.1.tgz",
@@ -9321,6 +10618,27 @@
                 "ajv": "^6.1.0",
                 "ajv-errors": "^1.0.0",
                 "ajv-keywords": "^3.1.0"
+            }
+        },
+        "scss-tokenizer": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+            "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "dev": true,
+            "requires": {
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
             }
         },
         "select-hose": {
@@ -9388,12 +10706,6 @@
                     "dev": true
                 }
             }
-        },
-        "serialize-javascript": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.0.tgz",
-            "integrity": "sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==",
-            "dev": true
         },
         "serve-index": {
             "version": "1.9.1",
@@ -9768,6 +11080,15 @@
                 }
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -9903,6 +11224,23 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
         "ssri": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -9923,6 +11261,391 @@
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
             "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==",
             "dev": true
+        },
+        "standard": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
+            "integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
+            "dev": true,
+            "requires": {
+                "eslint": "~4.18.0",
+                "eslint-config-standard": "11.0.0",
+                "eslint-config-standard-jsx": "5.0.0",
+                "eslint-plugin-import": "~2.9.0",
+                "eslint-plugin-node": "~6.0.0",
+                "eslint-plugin-promise": "~3.7.0",
+                "eslint-plugin-react": "~7.7.0",
+                "eslint-plugin-standard": "~3.0.1",
+                "standard-engine": "~8.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+                    "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "acorn": {
+                            "version": "3.3.0",
+                            "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                            "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                            "dev": true
+                        }
+                    }
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+                    "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "chardet": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+                    "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "eslint": {
+                    "version": "4.18.2",
+                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
+                    "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.3.0",
+                        "babel-code-frame": "^6.22.0",
+                        "chalk": "^2.1.0",
+                        "concat-stream": "^1.6.0",
+                        "cross-spawn": "^5.1.0",
+                        "debug": "^3.1.0",
+                        "doctrine": "^2.1.0",
+                        "eslint-scope": "^3.7.1",
+                        "eslint-visitor-keys": "^1.0.0",
+                        "espree": "^3.5.2",
+                        "esquery": "^1.0.0",
+                        "esutils": "^2.0.2",
+                        "file-entry-cache": "^2.0.0",
+                        "functional-red-black-tree": "^1.0.1",
+                        "glob": "^7.1.2",
+                        "globals": "^11.0.1",
+                        "ignore": "^3.3.3",
+                        "imurmurhash": "^0.1.4",
+                        "inquirer": "^3.0.6",
+                        "is-resolvable": "^1.0.0",
+                        "js-yaml": "^3.9.1",
+                        "json-stable-stringify-without-jsonify": "^1.0.1",
+                        "levn": "^0.3.0",
+                        "lodash": "^4.17.4",
+                        "minimatch": "^3.0.2",
+                        "mkdirp": "^0.5.1",
+                        "natural-compare": "^1.4.0",
+                        "optionator": "^0.8.2",
+                        "path-is-inside": "^1.0.2",
+                        "pluralize": "^7.0.0",
+                        "progress": "^2.0.0",
+                        "require-uncached": "^1.0.3",
+                        "semver": "^5.3.0",
+                        "strip-ansi": "^4.0.0",
+                        "strip-json-comments": "~2.0.1",
+                        "table": "4.0.2",
+                        "text-table": "~0.2.0"
+                    }
+                },
+                "eslint-config-standard": {
+                    "version": "11.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+                    "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+                    "dev": true
+                },
+                "eslint-plugin-import": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+                    "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "^1.1.1",
+                        "contains-path": "^0.1.0",
+                        "debug": "^2.6.8",
+                        "doctrine": "1.5.0",
+                        "eslint-import-resolver-node": "^0.3.1",
+                        "eslint-module-utils": "^2.1.1",
+                        "has": "^1.0.1",
+                        "lodash": "^4.17.4",
+                        "minimatch": "^3.0.3",
+                        "read-pkg-up": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "doctrine": {
+                            "version": "1.5.0",
+                            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                            "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                            "dev": true,
+                            "requires": {
+                                "esutils": "^2.0.2",
+                                "isarray": "^1.0.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "eslint-plugin-node": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+                    "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+                    "dev": true,
+                    "requires": {
+                        "ignore": "^3.3.6",
+                        "minimatch": "^3.0.4",
+                        "resolve": "^1.3.3",
+                        "semver": "^5.4.1"
+                    }
+                },
+                "eslint-plugin-promise": {
+                    "version": "3.7.0",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
+                    "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+                    "dev": true
+                },
+                "eslint-plugin-standard": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+                    "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+                    "dev": true
+                },
+                "eslint-scope": {
+                    "version": "3.7.3",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+                    "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "espree": {
+                    "version": "3.5.4",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+                    "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^5.5.0",
+                        "acorn-jsx": "^3.0.0"
+                    }
+                },
+                "external-editor": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+                    "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+                    "dev": true,
+                    "requires": {
+                        "chardet": "^0.4.0",
+                        "iconv-lite": "^0.4.17",
+                        "tmp": "^0.0.33"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+                    "dev": true
+                },
+                "file-entry-cache": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+                    "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+                    "dev": true,
+                    "requires": {
+                        "flat-cache": "^1.2.1",
+                        "object-assign": "^4.0.1"
+                    }
+                },
+                "flat-cache": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+                    "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+                    "dev": true,
+                    "requires": {
+                        "circular-json": "^0.3.1",
+                        "graceful-fs": "^4.1.2",
+                        "rimraf": "~2.6.2",
+                        "write": "^0.2.1"
+                    }
+                },
+                "inquirer": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+                    "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.0",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^2.0.4",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.3.0",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rx-lite": "^4.0.8",
+                        "rx-lite-aggregates": "^4.0.8",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "through": "^2.3.6"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+                    "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "table": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+                    "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.2.3",
+                        "ajv-keywords": "^2.1.0",
+                        "chalk": "^2.1.0",
+                        "lodash": "^4.17.4",
+                        "slice-ansi": "1.0.0",
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "write": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                    "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                    "dev": true,
+                    "requires": {
+                        "mkdirp": "^0.5.1"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
+                }
+            }
+        },
+        "standard-engine": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
+            "integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
+            "dev": true,
+            "requires": {
+                "deglob": "^2.1.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+            },
+            "dependencies": {
+                "get-stdin": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+                    "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+                    "dev": true
+                }
+            }
         },
         "static-extend": {
             "version": "0.1.2",
@@ -9950,6 +11673,15 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "dev": true
+        },
+        "stdout-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+            "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
         },
         "stream-browserify": {
             "version": "2.0.2",
@@ -9990,6 +11722,12 @@
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
         },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
+        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -10021,7 +11759,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -10045,6 +11782,15 @@
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
+        },
+        "strip-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^4.0.1"
+            }
         },
         "strip-json-comments": {
             "version": "2.0.1",
@@ -10092,6 +11838,15 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "svg-to-vue": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.4.0.tgz",
+            "integrity": "sha512-g/ZHtEFf4QDsDtTk9tuYX/MJ2HESTUBMTkuLoffQGQ3xMtlmD9Ec4YyTgmMkP1P8QJtWWu2FiGdOnlKaXc/X/Q==",
+            "dev": true,
+            "requires": {
+                "svgo": "^1.1.1"
             }
         },
         "svgo": {
@@ -10160,6 +11915,17 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
             "dev": true
+        },
+        "tar": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+            "dev": true,
+            "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.12",
+                "inherits": "2"
+            }
         },
         "terser": {
             "version": "3.17.0",
@@ -10351,6 +12117,31 @@
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
         },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "trim-newlines": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "true-case-path": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.2"
+            }
+        },
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -10361,6 +12152,21 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
         "type": {
@@ -10415,6 +12221,53 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
+                }
+            }
+        },
+        "uglifyjs-webpack-plugin": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
+            "integrity": "sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==",
+            "dev": true,
+            "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^1.7.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.6.0",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                },
+                "serialize-javascript": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+                    "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "uglify-js": {
+                    "version": "3.8.0",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+                    "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "~2.20.3",
+                        "source-map": "~0.6.1"
+                    }
                 }
             }
         },
@@ -10595,6 +12448,35 @@
                 }
             }
         },
+        "url-loader": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.3.0.tgz",
+            "integrity": "sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.2.3",
+                "mime": "^2.4.4",
+                "schema-utils": "^2.5.0"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.6.4",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+                    "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.10.2",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                }
+            }
+        },
         "url-parse": {
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
@@ -10636,8 +12518,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util.promisify": {
             "version": "1.0.0",
@@ -10687,6 +12568,17 @@
             "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
             "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
             "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
         },
         "vm-browserify": {
             "version": "1.1.2",
@@ -10804,6 +12696,16 @@
             "requires": {
                 "hash-sum": "^1.0.2",
                 "loader-utils": "^1.0.2"
+            }
+        },
+        "vue-svg-loader": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.12.0.tgz",
+            "integrity": "sha512-pg8H6iKCj+DAC7FZuxdfGJMHiFpJPv/YyoN1M7Iqlf+Hu4eU6Q/W/sEFx978syQA+aOx0NXrp+uQUAajqQvXbQ==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.2.3",
+                "svg-to-vue": "^0.4.0"
             }
         },
         "vue-template-compiler": {
@@ -11153,6 +13055,15 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
         },
         "wordwrap": {
             "version": "1.0.0",

--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -25,6 +25,7 @@
       :onFormButtonClick="onFormButtonClick"
       :onListButtonClick="onListButtonClick"
       :onLinkClick="onLinkClick"
+      :mode-data="modeData"
       @setChatMode="setChatMode"
     />
     <template v-if="!showLongTextInput">
@@ -55,12 +56,12 @@
 </template>
 
 <script>
-import Header from './Header.vue'
-import MessageList from './MessageList.vue'
-import UserInput from './UserInput.vue'
-import LongTextUserInput from './LongTextUserInput.vue'
+  import Header from './Header.vue'
+  import MessageList from './MessageList.vue'
+  import UserInput from './UserInput.vue'
+  import LongTextUserInput from './LongTextUserInput.vue'
 
-export default {
+  export default {
   components: {
     Header,
     MessageList,
@@ -183,6 +184,10 @@ export default {
     initialText: {
         type: String,
         default: null
+    },
+    modeData: {
+      type: Object,
+      required: true
     }
   },
   data() {

--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -11,7 +11,6 @@
       :onRestartButtonClick="onRestartButtonClick"
       :colors="colors"
       :isOpen="isOpen"
-
     />
     <MessageList
       v-if="showMessages"
@@ -39,7 +38,10 @@
         :lastMessage="lastMessage"
         :showFile="showFile"
         :placeholder="placeholder"
-        :colors="colors" />
+        :colors="colors"
+        :mode-data="modeData"
+        @setChatMode="setChatMode"
+      />
     </template>
     <template v-else>
       <LongTextUserInput

--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -25,6 +25,7 @@
       :onFormButtonClick="onFormButtonClick"
       :onListButtonClick="onListButtonClick"
       :onLinkClick="onLinkClick"
+      @setChatMode="setChatMode"
     />
     <template v-if="!showLongTextInput">
       <UserInput
@@ -216,6 +217,12 @@ export default {
     lastMessage() {
       if (this.messages.length == 0) return {}
       return this.messages[this.messages.length - 1]
+    }
+  },
+  methods: {
+    setChatMode(mode) {
+      console.log("ChatWindow");
+      this.$emit('setChatMode', mode);
     }
   }
 }

--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -237,7 +237,6 @@
   },
   methods: {
     setChatMode(mode) {
-      console.log("ChatWindow");
       this.$emit('setChatMode', mode);
     }
   }

--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -193,6 +193,15 @@
   data() {
     return {}
   },
+  watch: {
+    modeData(newValue, oldValue) {
+      if (newValue.mode === 'custom') {
+        this.agentProfile.teamName = 'You are now speaking to [AGENT_NAME]';
+      } else {
+        this.agentProfile.teamName = '';
+      }
+    }
+  },
   computed: {
     messages() {
       let messages = this.messageList

--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -41,18 +41,11 @@
 
       console.log("Simulating H2H takeover");
       this.$emit('setChatMode', {
-        mode: 'custom'
+        mode: 'custom',
+        options: {
+          'callback_id': this.data.elements.callback_id
+        }
       });
-
-      setTimeout(() => {
-        console.log("Simulating H2H giveback");
-        this.$emit('setChatMode', {
-          mode: 'webchat',
-          options: {
-            'callback_id': this.data.elements.callback_id
-          }
-        });
-      }, 7500);
     }
   }
 </script>

--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -31,15 +31,7 @@
         required: true
       }
     },
-    watch: {
-      modeData(newValue, oldValue) {
-        console.log("H2H: modeData changed from/to ", oldValue, newValue);
-      }
-    },
     mounted() {
-      console.log(this.data);
-
-      console.log("Simulating H2H takeover");
       this.$emit('setChatMode', {
         mode: 'custom',
         options: {

--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -25,6 +25,15 @@
       messageColors: {
         type: Object,
         required: true
+      },
+      modeData: {
+        type: Object,
+        required: true
+      }
+    },
+    watch: {
+      modeData(newValue, oldValue) {
+        console.log("H2H: modeData changed from/to ", oldValue, newValue);
       }
     },
     mounted() {
@@ -35,15 +44,15 @@
         mode: 'custom'
       });
 
-      // setTimeout(() => {
-      //   console.log("Simulating H2H giveback");
-      //   this.$emit('setChatMode', {
-      //     mode: 'webchat',
-      //     options: {
-      //       'callback_id': this.data.elements.callback_id
-      //     }
-      //   });
-      // }, 2000);
+      setTimeout(() => {
+        console.log("Simulating H2H giveback");
+        this.$emit('setChatMode', {
+          mode: 'webchat',
+          options: {
+            'callback_id': this.data.elements.callback_id
+          }
+        });
+      }, 7500);
     }
   }
 </script>

--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -8,7 +8,43 @@
 
 <script>
   export default {
-    name: "HandToHumanMessage"
+    name: "HandToHumanMessage",
+    props: {
+      author: {
+        type: String,
+        required: true
+      },
+      type: {
+        type: String,
+        required: true
+      },
+      data: {
+        type: Object,
+        required: true
+      },
+      messageColors: {
+        type: Object,
+        required: true
+      }
+    },
+    mounted() {
+      console.log(this.data);
+
+      console.log("Simulating H2H takeover");
+      this.$emit('setChatMode', {
+        mode: 'custom'
+      });
+
+      // setTimeout(() => {
+      //   console.log("Simulating H2H giveback");
+      //   this.$emit('setChatMode', {
+      //     mode: 'webchat',
+      //     options: {
+      //       'callback_id': this.data.elements.callback_id
+      //     }
+      //   });
+      // }, 2000);
+    }
   }
 </script>
 

--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -1,0 +1,17 @@
+<template>
+    <div
+      class="mt mt-text"
+    >
+      <span>[Hand-to-Human]</span>
+    </div>
+</template>
+
+<script>
+  export default {
+    name: "HandToHumanMessage"
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/assets/js/components/Launcher.vue
+++ b/resources/assets/js/components/Launcher.vue
@@ -221,7 +221,6 @@
   },
   methods: {
     setChatMode(mode) {
-      console.log("Launcher");
       this.$emit('setChatMode', mode);
     }
   }

--- a/resources/assets/js/components/Launcher.vue
+++ b/resources/assets/js/components/Launcher.vue
@@ -28,14 +28,15 @@
       :confirmationMessage="confirmationMessage"
       :initialText="initialText"
       :fullScreen="fullScreen"
+      :mode-data="modeData"
       @setChatMode="setChatMode"
     />
   </div>
 </template>
 <script>
-import ChatWindow from './ChatWindow.vue'
+  import ChatWindow from './ChatWindow.vue'
 
-export default {
+  export default {
   props: {
     contentEditable: {
       type: Boolean,
@@ -197,6 +198,10 @@ export default {
     alwaysScrollToBottom: {
       type: Boolean,
       default: () => false
+    },
+    modeData: {
+      type: Object,
+      required: true
     }
   },
   data () {
@@ -208,9 +213,9 @@ export default {
     ChatWindow
   },
   created() {
-    let localStorageSettings = JSON.parse(window.localStorage.getItem('opendialog-webchat'));
-    if (localStorageSettings && localStorageSettings.mode === 'custom') {
-      this.setChatMode('custom');
+    let sessionStorageSettings = JSON.parse(window.sessionStorage.getItem('opendialog-webchat'));
+    if (sessionStorageSettings && sessionStorageSettings.mode === 'custom') {
+      this.setChatMode(sessionStorageSettings);
     }
   },
   methods: {

--- a/resources/assets/js/components/Launcher.vue
+++ b/resources/assets/js/components/Launcher.vue
@@ -28,6 +28,7 @@
       :confirmationMessage="confirmationMessage"
       :initialText="initialText"
       :fullScreen="fullScreen"
+      @setChatMode="setChatMode"
     />
   </div>
 </template>
@@ -205,6 +206,18 @@ export default {
   },
   components: {
     ChatWindow
+  },
+  created() {
+    let localStorageSettings = JSON.parse(window.localStorage.getItem('opendialog-webchat'));
+    if (localStorageSettings && localStorageSettings.mode === 'custom') {
+      this.setChatMode('custom');
+    }
+  },
+  methods: {
+    setChatMode(mode) {
+      console.log("Launcher");
+      this.$emit('setChatMode', mode);
+    }
   }
 }
 </script>

--- a/resources/assets/js/components/Launcher.vue
+++ b/resources/assets/js/components/Launcher.vue
@@ -35,6 +35,7 @@
 </template>
 <script>
   import ChatWindow from './ChatWindow.vue'
+  import SessionStorageMixin from "../mixins/SessionStorageMixin";
 
   export default {
   props: {
@@ -212,10 +213,10 @@
   components: {
     ChatWindow
   },
+  mixins: [SessionStorageMixin],
   created() {
-    let sessionStorageSettings = JSON.parse(window.sessionStorage.getItem('opendialog-webchat'));
-    if (sessionStorageSettings && sessionStorageSettings.mode === 'custom') {
-      this.setChatMode(sessionStorageSettings);
+    if (this.isCustomModeInSession()) {
+      this.setChatMode(this.getModeDataInSession());
     }
   },
   methods: {

--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -106,6 +106,7 @@
       :author="message.author"
       :type="message.type"
       :messageColors="determineMessageColors()"
+      @setChatMode="setChatMode"
     />
     <DatetimeFakeMessage v-else-if="message.type === 'datetime'" :message="message" />
 
@@ -223,6 +224,10 @@ export default {
       return this.message.author === "me"
         ? this.sentColorsStyle()
         : this.receivedColorsStyle();
+    },
+    setChatMode(mode) {
+      console.log("Message");
+      this.$emit('setChatMode', mode);
     }
   }
 };

--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -106,6 +106,7 @@
       :author="message.author"
       :type="message.type"
       :messageColors="determineMessageColors()"
+      :mode-data="modeData"
       @setChatMode="setChatMode"
     />
     <DatetimeFakeMessage v-else-if="message.type === 'datetime'" :message="message" />
@@ -123,23 +124,23 @@
 </template>
 
 <script>
-import DatetimeFakeMessage from "./DatetimeFakeMessage.vue";
-import CarouselListMessage from "./CarouselListMessage.vue";
-import ListMessage from "./ListMessage.vue";
-import ImageMessage from "./ImageMessage.vue";
-import FormMessage from "./FormMessage.vue";
-import FormResponseMessage from "./FormResponseMessage.vue";
-import ButtonMessage from "./ButtonMessage.vue";
-import ButtonResponseMessage from "./ButtonResponseMessage.vue";
-import RichMessage from "./RichMessage.vue";
-import TextMessage from "./TextMessage.vue";
-import LongTextMessage from "./LongTextMessage.vue";
-import TypingMessage from "./TypingMessage.vue";
-import AuthorMessage from "./AuthorMessage.vue";
-import chatIcon from "./assets/chat-icon.svg";
-import HandToHumanMessage from "./HandToHumanMessage";
+  import DatetimeFakeMessage from "./DatetimeFakeMessage.vue";
+  import CarouselListMessage from "./CarouselListMessage.vue";
+  import ListMessage from "./ListMessage.vue";
+  import ImageMessage from "./ImageMessage.vue";
+  import FormMessage from "./FormMessage.vue";
+  import FormResponseMessage from "./FormResponseMessage.vue";
+  import ButtonMessage from "./ButtonMessage.vue";
+  import ButtonResponseMessage from "./ButtonResponseMessage.vue";
+  import RichMessage from "./RichMessage.vue";
+  import TextMessage from "./TextMessage.vue";
+  import LongTextMessage from "./LongTextMessage.vue";
+  import TypingMessage from "./TypingMessage.vue";
+  import AuthorMessage from "./AuthorMessage.vue";
+  import chatIcon from "./assets/chat-icon.svg";
+  import HandToHumanMessage from "./HandToHumanMessage";
 
-export default {
+  export default {
   data() {
     return {
       authorName: null
@@ -192,6 +193,10 @@ export default {
     },
     read: {
       type: Boolean
+    },
+    modeData: {
+      type: Object,
+      required: true
     }
   },
 

--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -100,6 +100,13 @@
 
 
     />
+    <HandToHumanMessage
+      v-else-if="message.type === 'hand-to-human'"
+      :data="message.data"
+      :author="message.author"
+      :type="message.type"
+      :messageColors="determineMessageColors()"
+    />
     <DatetimeFakeMessage v-else-if="message.type === 'datetime'" :message="message" />
 
     <span
@@ -129,6 +136,7 @@ import LongTextMessage from "./LongTextMessage.vue";
 import TypingMessage from "./TypingMessage.vue";
 import AuthorMessage from "./AuthorMessage.vue";
 import chatIcon from "./assets/chat-icon.svg";
+import HandToHumanMessage from "./HandToHumanMessage";
 
 export default {
   data() {
@@ -149,7 +157,8 @@ export default {
     TextMessage,
     LongTextMessage,
     TypingMessage,
-    AuthorMessage
+    AuthorMessage,
+    HandToHumanMessage
   },
   props: {
     message: {

--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -231,7 +231,6 @@
         : this.receivedColorsStyle();
     },
     setChatMode(mode) {
-      console.log("Message");
       this.$emit('setChatMode', mode);
     }
   }

--- a/resources/assets/js/components/MessageList.vue
+++ b/resources/assets/js/components/MessageList.vue
@@ -11,6 +11,7 @@
       :onLinkClick="onLinkClick"
       :onListButtonClick="onListButtonClick"
       :onFormButtonClick="onFormButtonClick"
+      @setChatMode="setChatMode"
     />
     <Message
       v-if="showTypingIndicator"
@@ -99,6 +100,10 @@ export default {
         this.$refs.scrollList.scrollTop >
           this.$refs.scrollList.scrollHeight - 300
       );
+    },
+    setChatMode(mode) {
+      console.log("MessageList");
+      this.$emit('setChatMode', mode);
     }
   },
   mounted() {

--- a/resources/assets/js/components/MessageList.vue
+++ b/resources/assets/js/components/MessageList.vue
@@ -108,7 +108,6 @@
       );
     },
     setChatMode(mode) {
-      console.log("MessageList");
       this.$emit('setChatMode', mode);
     }
   },

--- a/resources/assets/js/components/MessageList.vue
+++ b/resources/assets/js/components/MessageList.vue
@@ -2,6 +2,7 @@
   <div class="message-list" ref="scrollList" :style="{'--messageList-bkg': colors.messageList.bg}">
     <Message
       v-for="(message, idx) in messages"
+      v-show="message.mode === modeData.mode"
       :message="message"
       :read="message.read"
       :chatImageUrl="chatImageUrl"
@@ -11,6 +12,7 @@
       :onLinkClick="onLinkClick"
       :onListButtonClick="onListButtonClick"
       :onFormButtonClick="onFormButtonClick"
+      :mode-data="modeData"
       @setChatMode="setChatMode"
     />
     <Message
@@ -26,10 +28,10 @@
   </div>
 </template>
 <script>
-import Message from "./Message.vue";
-import chatIcon from "./assets/chat-icon.svg";
+  import Message from "./Message.vue";
+  import chatIcon from "./assets/chat-icon.svg";
 
-export default {
+  export default {
   components: {
     Message
   },
@@ -68,6 +70,10 @@ export default {
     },
     onLinkClick: {
       type: Function,
+      required: true
+    },
+    modeData: {
+      type: Object,
       required: true
     }
   },

--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -119,6 +119,7 @@
 
   import Comments from "@/components/Comments";
   import WebChat from "@/components/WebChat";
+  import SessionStorageMixin from "../mixins/SessionStorageMixin";
 
   const { detect } = require("detect-browser");
 const jstz = require("jstz");
@@ -129,6 +130,7 @@ export default {
     Comments,
     WebChat
   },
+  mixins: [SessionStorageMixin],
   data() {
     return {
       activeTab: "webchat",
@@ -839,7 +841,7 @@ export default {
     setChatMode(data) {
       console.log('Chat mode set to: ', data);
       this.modeData = data;
-      window.sessionStorage.setItem('opendialog-webchat', JSON.stringify(data));
+      this.setModeDataInSession(data);
     }
   }
 };

--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -839,7 +839,6 @@ export default {
       window.parent.postMessage({ height: "auto" }, "*");
     },
     setChatMode(data) {
-      console.log('Chat mode set to: ', data);
       this.modeData = data;
       this.setModeDataInSession(data);
     }

--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -100,6 +100,7 @@
         :user-timezone="userTimezone"
         :user-uuid="userUuid"
         :user-external-id="userExternalId"
+        :mode-data="modeData"
         @expandChat="expandChat"
         @toggleChatOpen="toggleChatOpen"
         @newMessage="newWebChatMessage"
@@ -111,15 +112,15 @@
 </template>
 
 <script>
-import axios from "axios";
-import { mapState } from "vuex";
+  import axios from "axios";
+  import {mapState} from "vuex";
 
-import cssVars from "css-vars-ponyfill";
+  import cssVars from "css-vars-ponyfill";
 
-import Comments from "@/components/Comments";
-import WebChat from "@/components/WebChat";
+  import Comments from "@/components/Comments";
+  import WebChat from "@/components/WebChat";
 
-const { detect } = require("detect-browser");
+  const { detect } = require("detect-browser");
 const jstz = require("jstz");
 
 export default {
@@ -225,7 +226,11 @@ export default {
       userFirstName: "",
       userLastName: "",
       userExternalId: "",
-      userUuid: ""
+      userUuid: "",
+      modeData: {
+        mode: 'webchat',
+        options: {}
+      }
     };
   },
   computed: {
@@ -293,6 +298,8 @@ export default {
     }
 
     this.initSettings();
+
+
   },
   methods: {
     newWebChatMessage() {
@@ -831,7 +838,8 @@ export default {
     },
     setChatMode(data) {
       console.log('Chat mode set to: ', data);
-      window.localStorage.setItem('opendialog-webchat', JSON.stringify(data));
+      this.modeData = data;
+      window.sessionStorage.setItem('opendialog-webchat', JSON.stringify(data));
     }
   }
 };

--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -104,6 +104,7 @@
         @toggleChatOpen="toggleChatOpen"
         @newMessage="newWebChatMessage"
         @switchToCommentsTab="switchToCommentsTab"
+        @setChatMode="setChatMode"
       />
     </div>
   </div>
@@ -827,6 +828,10 @@ export default {
       this.isMinimized = false;
       this.isOpen = true;
       window.parent.postMessage({ height: "auto" }, "*");
+    },
+    setChatMode(data) {
+      console.log('Chat mode set to: ', data);
+      window.localStorage.setItem('opendialog-webchat', JSON.stringify(data));
     }
   }
 };

--- a/resources/assets/js/components/UserInput.vue
+++ b/resources/assets/js/components/UserInput.vue
@@ -45,7 +45,11 @@
           class="user-input__button"
           v-if="modeData.mode === 'custom'"
         >
-          <button @click.stop="closeChat" class="end-chat-btn">End chat</button>
+          <button v-if="!confirmCloseChat" @click.stop="toggleConfirmCloseChat" class="end-chat-btn">End chat</button>
+          <div v-if="confirmCloseChat">
+            <span>Are you sure?</span>
+            <button @click.stop="closeChat">Yes</button> / <button @click.stop="toggleConfirmCloseChat">No</button>
+          </div>
         </div>
       </div>
     </form>
@@ -103,7 +107,8 @@
     return {
       file: null,
       inputActive: false,
-      textEntered: false
+      textEntered: false,
+      confirmCloseChat: false,
     };
   },
   methods: {
@@ -180,7 +185,12 @@
     _handleFileSubmit(file) {
       this.file = file;
     },
+    toggleConfirmCloseChat() {
+      this.confirmCloseChat = !this.confirmCloseChat;
+    },
     closeChat() {
+      this.confirmCloseChat = false;
+
       this.$emit('setChatMode', {
         mode: 'webchat',
         options: {

--- a/resources/assets/js/components/UserInput.vue
+++ b/resources/assets/js/components/UserInput.vue
@@ -181,7 +181,6 @@
       this.file = file;
     },
     closeChat() {
-      console.log(this.modeData);
       this.$emit('setChatMode', {
         mode: 'webchat',
         options: {

--- a/resources/assets/js/components/UserInput.vue
+++ b/resources/assets/js/components/UserInput.vue
@@ -40,6 +40,13 @@
         <div class="user-input__button">
           <button @click.prevent="_submitText" class="send-btn"></button>
         </div>
+
+        <div
+          class="user-input__button"
+          v-if="modeData.mode === 'custom'"
+        >
+          <button @click.stop="closeChat" class="end-chat-btn">End chat</button>
+        </div>
       </div>
     </form>
   </div>
@@ -48,9 +55,9 @@
 
 <script>
 
-import ExternalButtons from "./ExternalButtons.vue";
+  import ExternalButtons from "./ExternalButtons.vue";
 
-export default {
+  export default {
   components: {
     ExternalButtons
   },
@@ -84,6 +91,10 @@ export default {
       required: true
     },
     colors: {
+      type: Object,
+      required: true
+    },
+    modeData: {
       type: Object,
       required: true
     }
@@ -168,6 +179,15 @@ export default {
     },
     _handleFileSubmit(file) {
       this.file = file;
+    },
+    closeChat() {
+      console.log(this.modeData);
+      this.$emit('setChatMode', {
+        mode: 'webchat',
+        options: {
+          'callback_id': this.modeData.options.callback_id
+        }
+      });
     }
   }
 };

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -220,8 +220,6 @@ export default {
     modeData(newValue, oldValue) {
       chatService.setModeData(newValue);
 
-
-
       if (oldValue.mode === "custom" && newValue.mode === "webchat") {
         // Convert the Hand-to-Human message to a text message
         console.log(this.messageList.map((message) => [message.data.text, message.mode]))

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -235,6 +235,10 @@ export default {
           data: {}
         });
       }
+
+      if (newValue.mode === 'custom') {
+        this.contentEditable = true;
+      }
     }
   },
   created() {

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -222,7 +222,6 @@ export default {
 
       if (oldValue.mode === "custom" && newValue.mode === "webchat") {
         // Convert the Hand-to-Human message to a text message
-        console.log(this.messageList.map((message) => [message.data.text, message.mode]))
         let filteredMessageList = this.messageList.filter((message) => message.mode === "webchat" && message.type === 'hand-to-human');
         let handToHumanMessage = filteredMessageList[filteredMessageList.length-1];
         handToHumanMessage.type = 'text';
@@ -723,7 +722,6 @@ export default {
       }
     },
     setChatMode(data) {
-      console.log("WebChat");
       this.$emit('setChatMode', data);
     }
   }

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -49,6 +49,7 @@
         :initial-text="initialText"
         @vbc-user-input-focus="userInputFocus"
         @vbc-user-input-blur="userInputBlur"
+        @setChatMode="setChatMode"
       />
       <div class="close-chat">
         <div class="close-chat__button" @click="toggleChatOpen"  >
@@ -163,7 +164,8 @@ export default {
       showTypingIndicator: false,
       users: [],
       userName: "",
-      uuid: this.userUuid
+      uuid: this.userUuid,
+      chatMode: "webchat"
     };
   },
   watch: {
@@ -829,8 +831,13 @@ export default {
             if (
               currentMessage.type === "button" ||
               currentMessage.type === "long_text" ||
-              currentMessage.type === "form"
+              currentMessage.type === "form" ||
+              currentMessage.type === "hand-to-human"
             ) {
+              if (currentMessage.type === "hand-to-human") {
+                currentMessage.data.text = currentMessage.data.elements.text;
+              }
+
               currentMessage.type = "text";
             }
 
@@ -948,6 +955,27 @@ export default {
           this.createUuid();
         }
       }
+    },
+    setChatMode(data) {
+      console.log("WebChat");
+
+      if (this.chatMode === "custom" && data.mode === "webchat") {
+        // Convert the Hand-to-Human message to a text message
+        let handToHumanMessage = this.messageList[this.messageList.length-1];
+        handToHumanMessage.type = 'text';
+        handToHumanMessage.data.text = handToHumanMessage.data.elements.text;
+
+        this.sendMessage({
+          type: "trigger",
+          author: "me",
+          callback_id: data.options.callback_id,
+          data: {}
+        });
+      }
+
+      this.chatMode = data.mode;
+
+      this.$emit('setChatMode', data);
     }
   }
 };

--- a/resources/assets/js/mixins/SessionStorageMixin.js
+++ b/resources/assets/js/mixins/SessionStorageMixin.js
@@ -1,0 +1,14 @@
+export default {
+  methods: {
+    getModeDataInSession() {
+      return JSON.parse(window.sessionStorage.getItem('opendialog-webchat'));
+    },
+    setModeDataInSession(data) {
+      window.sessionStorage.setItem('opendialog-webchat', JSON.stringify(data));
+    },
+    isCustomModeInSession() {
+      let sessionStorageSettings = this.getModeDataInSession();
+      return sessionStorageSettings && sessionStorageSettings.mode === 'custom';
+    }
+  }
+}

--- a/resources/assets/js/services/ChatService.js
+++ b/resources/assets/js/services/ChatService.js
@@ -1,0 +1,44 @@
+import WebChatMode from "./ChatServices/WebChatMode";
+import ConversiveMode from "./ChatServices/ConversiveMode";
+
+let ChatService = function() {
+  this.services = {
+    webchat: new WebChatMode(),
+    custom: new ConversiveMode(),
+  };
+
+  this.modeData = {
+    mode: "webchat",
+    options: {}
+  };
+};
+
+ChatService.prototype.getModeData = function() {
+  return this.modeData;
+};
+
+ChatService.prototype.setModeData = function(modeData) {
+  this.modeData = modeData;
+};
+
+ChatService.prototype.getMode = function() {
+  return this.modeData.mode;
+};
+
+ChatService.prototype.getActiveService = function() {
+  return this.services[this.getMode()];
+};
+
+ChatService.prototype.sendRequest = function(message) {
+  return this.getActiveService().sendRequest(message);
+};
+
+ChatService.prototype.sendResponseSuccess = function(response, webChatComponent) {
+  return this.getActiveService().sendResponseSuccess(response, webChatComponent);
+};
+
+ChatService.prototype.sendResponseError = function(error, webChatComponent) {
+  return this.getActiveService().sendResponseError(error);
+};
+
+export default new ChatService();

--- a/resources/assets/js/services/ChatServices/ConversiveMode.js
+++ b/resources/assets/js/services/ChatServices/ConversiveMode.js
@@ -1,0 +1,20 @@
+let ConversiveMode = function() {
+  this.name = "custom";
+};
+
+ConversiveMode.prototype.sendRequest = function(message) {
+  return new Promise((resolve, reject) => {
+    console.log("Using Conversive mode");
+    resolve();
+  });
+};
+
+ConversiveMode.prototype.sendResponseSuccess = function(response, webChatComponent) {
+  console.log("Conversive mode response success", webChatComponent.modeData);
+};
+
+ConversiveMode.prototype.sendResponseError = function(error, webChatComponent) {
+  console.log("Conversive mode response error", webChatComponent.modeData);
+};
+
+export default ConversiveMode;

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -1,0 +1,295 @@
+import axios from "axios";
+
+let WebChatMode = function() {
+  this.name = "webchat";
+};
+
+WebChatMode.prototype.sendRequest = function(message) {
+    if (
+      message.type === "chat_open" ||
+      message.type === "url_click" ||
+      message.type === "trigger" ||
+      message.type === "form_response" ||
+      message.type === "webchat_list_response" ||
+      message.data.text.length > 0
+    ) {
+      // Make a copy of the message to send to the backend.
+      // This is needed so that the author change will not affect this.messageList.
+      const msgCopy = Object.assign({}, message);
+
+      // Set the message author ID.
+      msgCopy.author = msgCopy.user_id;
+
+      const webchatMessage = {
+        notification: "message",
+        user_id: msgCopy.user_id,
+        author: msgCopy.author,
+        message_id: msgCopy.id,
+        content: msgCopy
+      };
+
+      // Need to add error handling here
+      return axios.post("/incoming/webchat", webchatMessage);
+    } else {
+      return new Promise((resolve, reject) => resolve(null));
+    }
+};
+
+WebChatMode.prototype.sendResponseSuccess = function(response, webChatComponent) {
+  if (response === null) {
+    return;
+  }
+
+  if (response.data instanceof Array) {
+    response.data.forEach((message, i) => {
+      if (!message) {
+        webChatComponent.contentEditable = true;
+      } else {
+        if (i === 0) {
+          if (
+            (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
+            !message.data.hideavatar
+          ) {
+            const authorMsg = webChatComponent.newAuthorMessage(message);
+
+            webChatComponent.messageList.push(authorMsg);
+          }
+
+          webChatComponent.messageList.push({
+            author: "them",
+            type: "typing",
+            mode: webChatComponent.modeData.mode,
+            data: {
+              animate: webChatComponent.messageAnimation
+            }
+          });
+        }
+
+        setTimeout(() => {
+          webChatComponent.$emit("newMessage", message);
+
+          /* eslint-disable no-param-reassign */
+          message.data.animate = webChatComponent.messageAnimation;
+
+          if (
+            i === 0 ||
+            !webChatComponent.hideTypingIndicatorOnInternalMessages
+          ) {
+            const lastMessage = webChatComponent.messageList[
+            webChatComponent.messageList.length - 1
+              ];
+            lastMessage.type = message.type;
+            lastMessage.data = message.data;
+
+            if (i === 0 && response.data.length > 1) {
+              lastMessage.data.first = true;
+            }
+
+            if (i > 0 && i < response.data.length - 1) {
+              lastMessage.data.middle = true;
+            }
+
+            if (i > 0 && i === response.data.length - 1) {
+              lastMessage.data.last = true;
+            }
+
+            webChatComponent.$root.$emit("scroll-down-message-list");
+            setTimeout(() => {
+              webChatComponent.$root.$emit("scroll-down-message-list");
+            }, 50);
+          } else {
+            if (i > 0 && i === response.data.length - 1) {
+              /* eslint-disable no-param-reassign */
+              message.data.lastInternal = true;
+            }
+
+            message.mode = webChatComponent.modeData.mode;
+            webChatComponent.messageList.push(message);
+          }
+
+          if (message.data) {
+            webChatComponent.contentEditable = !message.data.disable_text;
+          }
+
+          if (!webChatComponent.hideTypingIndicatorOnInternalMessages) {
+            if (i < response.data.length - 1) {
+              webChatComponent.$nextTick(() => {
+                webChatComponent.$nextTick(() => {
+                  webChatComponent.messageList.push({
+                    author: "them",
+                    type: "typing",
+                    mode: webChatComponent.modeData.mode,
+                    data: {
+                      animate: webChatComponent.messageAnimation
+                    }
+                  });
+                });
+              });
+            }
+          }
+        }, (i + 1) * webChatComponent.messageDelay);
+
+        window.parent.postMessage(
+          { dataLayerEvent: "message_received_from_chatbot" },
+          "*"
+        );
+      }
+    });
+  } else if (response.data) {
+    const message = response.data;
+
+    if (newMsg.type === "chat_open") {
+      if (message && message.data) {
+        if (
+          (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
+          !message.data.hideavatar
+        ) {
+          const authorMsg = webChatComponent.newAuthorMessage(message);
+
+          webChatComponent.messageList.push(authorMsg);
+        }
+
+        webChatComponent.messageList.push({
+          author: "them",
+          type: "typing",
+          mode: webChatComponent.modeData.mode,
+          data: {
+            animate: webChatComponent.messageAnimation
+          }
+        });
+
+        setTimeout(() => {
+          const lastMessage = webChatComponent.messageList[
+          webChatComponent.messageList.length - 1
+            ];
+
+          webChatComponent.$emit("newMessage", message);
+
+          message.data.animate = webChatComponent.messageAnimation;
+
+          lastMessage.type = message.type;
+          lastMessage.data = message.data;
+
+          webChatComponent.contentEditable = !message.data.disable_text;
+        }, webChatComponent.messageDelay);
+      } else {
+        // If we don't get data about whether to disable the editor, turn it on
+        webChatComponent.contentEditable = true;
+      }
+    } else {
+      if (message.data) {
+        if (
+          (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
+          !message.data.hideavatar
+        ) {
+          const authorMsg = webChatComponent.newAuthorMessage(message);
+
+          webChatComponent.messageList.push(authorMsg);
+        }
+
+        webChatComponent.messageList.push({
+          author: "them",
+          type: "typing",
+          data: {
+            animate: webChatComponent.messageAnimation
+          }
+        });
+      }
+      setTimeout(() => {
+        // Only add a message to the list if it is a message object
+        if (typeof message === "object" && message !== null) {
+          const lastMessage = webChatComponent.messageList[
+          webChatComponent.messageList.length - 1
+            ];
+
+          webChatComponent.$emit("newMessage", message);
+
+          message.data.animate = webChatComponent.messageAnimation;
+
+          lastMessage.type = message.type;
+          lastMessage.data = message.data;
+
+          webChatComponent.$root.$emit("scroll-down-message-list");
+          setTimeout(() => {
+            webChatComponent.$root.$emit("scroll-down-message-list");
+          }, 50);
+        }
+
+        if (message.data) {
+          webChatComponent.contentEditable = !message.data.disable_text;
+        }
+
+        if (message.type === "longtext") {
+          if (message.data.character_limit) {
+            webChatComponent.maxInputCharacters = message.data.character_limit;
+          }
+
+          if (message.data.submit_text) {
+            webChatComponent.buttonText = message.data.submit_text;
+          }
+
+          if (message.data.text) {
+            webChatComponent.headerText = message.data.text;
+          }
+
+          if (message.data.placeholder) {
+            webChatComponent.placeholder = message.data.placeholder;
+          }
+
+          if (message.data.initial_text) {
+            webChatComponent.initialText = message.data.initial_text;
+          } else {
+            webChatComponent.initialText = null;
+          }
+
+          if (message.data.confirmation_text) {
+            webChatComponent.confirmationMessage = message.data.confirmation_text;
+          } else {
+            webChatComponent.confirmationMessage = null;
+          }
+
+          webChatComponent.showLongTextInput = true;
+          webChatComponent.showMessages = false;
+        }
+      }, webChatComponent.messageDelay);
+
+      window.parent.postMessage(
+        { dataLayerEvent: "message_received_from_chatbot" },
+        "*"
+      );
+    }
+  }
+};
+
+WebChatMode.prototype.sendResponseError = function(error, webChatComponent) {
+  setTimeout(() => {
+    const message = {
+      type: "text",
+      author: "them",
+      data: {
+        date: moment()
+          .tz("UTC")
+          .format("ddd D MMM"),
+        time: moment()
+          .tz("UTC")
+          .format("hh:mm A"),
+        text: "We're sorry, that didn't work, please try again"
+      }
+    };
+
+    const lastMessage = webChatComponent.messageList[webChatComponent.messageList.length - 1];
+
+    if (webChatComponent.useBotName || webChatComponent.useBotAvatar) {
+      const authorMsg = webChatComponent.newAuthorMessage(message);
+      webChatComponent.messageList.push(authorMsg);
+    }
+
+    lastMessage.type = message.type;
+    lastMessage.data = message.data;
+
+    webChatComponent.$root.$emit("scroll-down-message-list");
+  }, webChatComponent.messageDelay);
+};
+
+
+export default WebChatMode;


### PR DESCRIPTION
This PR introduces the concept of chat "modes": webchat & custom. The mode is currently changed by a received Hand-to-Human message (see `HandToHumanMessage.vue`) or the "End chat" button (added to `UserInput.vue`). The mode is emitted up to `OpenDialogChat.vue` and then propagated back down thru relevant child components. All desired functionality is implemented in watch methods on this mode prop, which allows us to simply emit the `setChatMode` event from any involved component and know that the desired functionality will be executed.

Alongside this a `ChatService` has been created, which allows for a the `WebChat` component to be _somewhat_ agnostic to the mode that it is in. The `ChatService` currently exposes three methods, `sendRequest`, `sendResponseSuccess` & `sendResponseError`, which are implemented by both a `WebChatService` and a `ConversiveChatService`. When the mode is changed, the active service within the `ChatService` is changed. The methods are likely to increase as we consider additional functionality (such as typing indicators).