### PR TITLE
hides team name when in full page messages

### DIFF
--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -12,6 +12,8 @@
       :colors="colors"
       :isOpen="isOpen"
       :ctaText="ctaText"
+      :showFullPageFormInput="showFullPageFormInput"
+      :showFullPageRichInput="showFullPageRichInput"
     />
     <MessageList
       v-if="showMessages"

--- a/resources/assets/js/components/Header.vue
+++ b/resources/assets/js/components/Header.vue
@@ -16,7 +16,7 @@
       </div>
 
       <div class="header-nav">
-        <div class="header-nav__team-name">
+        <div class="header-nav__team-name" v-if="!showFullPageFormInput && !showFullPageRichInput">
           <span v-if="teamName" v-html="teamName"></span>
         </div>
 
@@ -93,7 +93,15 @@ export default {
     isOpen: {
       type: Boolean,
       default: () => false
-    }
+    },
+    showFullPageFormInput: {
+      type: Boolean,
+      default: true
+    },
+    showFullPageRichInput: {
+      type: Boolean,
+      default: true
+    },
   }
 };
 </script>


### PR DESCRIPTION
Passes the show full-page rich and form properties into the header to allow it to hide the team name when full-page messages are shown