### PR TITLE
Fixing typing indicator

### DIFF
--- a/resources/assets/js/services/clients/ConversiveClient.js
+++ b/resources/assets/js/services/clients/ConversiveClient.js
@@ -147,7 +147,7 @@ ConversiveClient.prototype.sendMessage = function(message, sessionToken) {
 
 ConversiveClient.prototype.sendTypingMessage = function(text, sessionToken) {
   return this.makeRequest("sendTypingMessage", {
-    b: text,
+    b: "=" + text,
     t: sessionToken,
     rsn: this.requestSerialNumber,
   });


### PR DESCRIPTION
This PR adds a "=" before typing indicator text that is sent to Conversive. This fixes the issue where this text was continuously appended and lacking the first character.