### PR TITLE
Sending company name & headcount to Conversive

### DIFF
--- a/resources/assets/js/services/clients/ConversiveClient.js
+++ b/resources/assets/js/services/clients/ConversiveClient.js
@@ -180,7 +180,7 @@ ConversiveClient.prototype.prepareChatData = function(chatData, historyDataOnly 
   if (historyDataOnly) {
     keys = ['history'];
   } else {
-    keys = ['email', 'fullname', 'loc', 'phone']
+    keys = ['email', 'fullname', 'loc', 'phone', 'company', 'headcount']
   }
 
   let data = Object.keys(chatData).filter((key) => {


### PR DESCRIPTION
This PR allows the hand-to-human message template to pass `company` and `headcount` attributes to Conversive. It is related to https://github.com/GreenShootLabs/avaya/pull/24 which updates the message template.