### PR TITLE
Old conversive conversations should not be visible when user re-enters a conversation

### DIFF
--- a/resources/assets/js/components/MessageList.vue
+++ b/resources/assets/js/components/MessageList.vue
@@ -2,7 +2,7 @@
   <div class="message-list" ref="scrollList" :style="{'--messageList-bkg': colors.messageList.bg}">
     <Message
       v-for="(message, idx) in messages"
-      v-show="message.mode === modeData.mode"
+      v-show="shouldShowMessage(message)"
       :message="message"
       :read="message.read"
       :chatImageUrl="chatImageUrl"
@@ -119,7 +119,14 @@
     },
     setChatMode(mode) {
       this.$emit('setChatMode', mode);
-    }
+    },
+    shouldShowMessage(message) {
+      let isModeSame = message.mode === this.modeData.mode;
+      let isWebchatMode = message.mode === 'webchat';
+      let isCustomMode = message.mode === 'custom';
+      let isFromSameInstance = message.modeInstance === this.modeData.modeInstance;
+      return (isModeSame && isWebchatMode) || (isModeSame && isCustomMode && isFromSameInstance);
+    },
   },
   mounted() {
     this._scrollDown(false);

--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -254,6 +254,7 @@ export default {
       userUuid: "",
       modeData: {
         mode: 'webchat',
+        modeInstance: 0,
         options: {}
       }
     };
@@ -898,6 +899,8 @@ export default {
       window.parent.postMessage({ height: "auto" }, this.referrerUrl);
     },
     setChatMode(data) {
+      let currentModeData = this.getModeDataInSession();
+      data.modeInstance = data.modeInstance || currentModeData.modeInstance || 0;
       this.modeData = data;
       this.setModeDataInSession(data);
     }

--- a/resources/assets/js/services/ChatService.js
+++ b/resources/assets/js/services/ChatService.js
@@ -19,6 +19,7 @@ ChatService.prototype.getModeData = function() {
 
 ChatService.prototype.setModeData = function(modeData) {
   this.modeData = modeData;
+  this.getActiveService().setModeInstance(modeData.modeInstance);
 };
 
 ChatService.prototype.getMode = function() {
@@ -59,6 +60,10 @@ ChatService.prototype.initialiseChat = function(webChatComponent) {
 
 ChatService.prototype.destroyChat = function(webChatComponent) {
   return this.getActiveService().destroyChat(webChatComponent);
+};
+
+ChatService.prototype.setModeInstance = function(number) {
+  this.getActiveService().setModeInstance(number);
 };
 
 export default new ChatService();

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -376,4 +376,8 @@ WebChatMode.prototype.initialiseChat = function(webChatComponent) {
 
 WebChatMode.prototype.destroyChat = function(webChatComponent) {};
 
+WebChatMode.prototype.setModeInstance = function(number) {
+  this.modeInstance = number;
+};
+
 export default WebChatMode;

--- a/resources/assets/js/services/clients/ConversiveClient.js
+++ b/resources/assets/js/services/clients/ConversiveClient.js
@@ -46,7 +46,12 @@ ConversiveClient.prototype.makeRequest = function(apiFunction, options) {
   })
     .then((response) => {
       this.requestSerialNumber++;
-      return Promise.resolve(response.data);
+
+      if (response.data.s) {
+        return Promise.resolve(response.data);
+      } else {
+        return Promise.reject(response.data);
+      }
     });
 };
 
@@ -137,10 +142,16 @@ ConversiveClient.prototype.getMessagesAfter = async function(sessionToken) {
     sn: this.getSerialNumber(),
   })
     .then((response) => {
-      let messages = response.m;
-      if (messages.length > 0) {
-        let finalMessage = messages[messages.length - 1];
-        this.setSerialNumber(finalMessage.sn);
+      let messages;
+      if (response.m !== undefined) {
+        messages = response.m;
+
+        if (messages.length > 0) {
+          let finalMessage = messages[messages.length - 1];
+          this.setSerialNumber(finalMessage.sn);
+        }
+      } else {
+        messages = null;
       }
 
       return messages;


### PR DESCRIPTION
This PR ensures that messages from previous Conversive sessions aren't shown. It achieves this by adding a `modeInstance` property to the mode data stored in the `sessionStorage`. The PR also includes a few bits of general error handling.