### PR TITLE
Ensuring chat data sent to Conversive is formatted correctly

### DIFF
--- a/resources/assets/js/components/HandToHumanMessage.vue
+++ b/resources/assets/js/components/HandToHumanMessage.vue
@@ -33,7 +33,7 @@
           callback_id: this.data.elements.callback_id,
           teamName: '',
           markupData: {
-            starting_url: document.referrer || document.location.href || "",
+            starting_url: (document.referrer || document.location.href || "").split("?")[0],
             ...this.data.elements
           }
         }

--- a/resources/assets/js/services/clients/ConversiveClient.js
+++ b/resources/assets/js/services/clients/ConversiveClient.js
@@ -197,9 +197,11 @@ ConversiveClient.prototype.prepareChatData = function(chatData, historyDataOnly 
   let data = Object.keys(chatData).filter((key) => {
     return keys.includes(key);
   }).map((key) => {
+    let value = chatData[key].replace("=", "-");
+
     return {
       n: key,
-      v: chatData[key]
+      v: value
     }
   });
 


### PR DESCRIPTION
This PR removes query parameters from the `starting_url` property and ensures any instances of "=" in chat or engine data are replaced with "-".